### PR TITLE
Bug ojs resolve outofmemoryerror during paragraph batch operations by applying flush and clear 156

### DIFF
--- a/src/main/java/org/aper/web/domain/paragraph/service/ParagraphHelper.java
+++ b/src/main/java/org/aper/web/domain/paragraph/service/ParagraphHelper.java
@@ -9,6 +9,7 @@ import org.aper.web.global.handler.ErrorCode;
 import org.aper.web.global.handler.exception.ServiceException;
 import org.aper.web.global.security.UserDetailsImpl;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -30,10 +31,12 @@ public class ParagraphHelper {
         return episode;
     }
 
+    @Transactional
     public Episode validateEpisodeOwnership(Long episodeId, UserDetailsImpl userDetails) {
         return validateEpisode(episodeId, userDetails, true);
     }
 
+    @Transactional
     public Paragraph validateParagraphExists(String uuid) {
         return paragraphRepository.findByUuid(uuid)
                 .orElseThrow(() -> new ServiceException(ErrorCode.PARAGRAPH_NOT_FOUND));
@@ -54,6 +57,7 @@ public class ParagraphHelper {
         return paragraph.length() > 250 ? paragraph.substring(0, 250) + "..." : paragraph + "...";
     }
 
+    @Transactional
     public void updateEpisodeDescription(Long episodeId) {
         Episode episode = episodeRepository.findByIdWithParagraphs(episodeId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.EPISODE_NOT_FOUND));
@@ -69,6 +73,7 @@ public class ParagraphHelper {
         episodeRepository.save(episode);
     }
 
+    @Transactional
     public void updatePreviousParagraph(String previousUuid, String nextUuid, List<Paragraph> paragraphsToUpdate) {
         if (previousUuid != null) {
             Paragraph previousParagraph = paragraphRepository.findByUuid(previousUuid)
@@ -78,6 +83,7 @@ public class ParagraphHelper {
         }
     }
 
+    @Transactional
     public void updateNextParagraph(String previousUuid, String nextUuid, List<Paragraph> paragraphsToUpdate) {
         if (nextUuid != null) {
             Paragraph nextParagraph = paragraphRepository.findByUuid(nextUuid)

--- a/src/main/java/org/aper/web/domain/paragraph/service/ParagraphService.java
+++ b/src/main/java/org/aper/web/domain/paragraph/service/ParagraphService.java
@@ -1,7 +1,6 @@
 package org.aper.web.domain.paragraph.service;
 
 import com.aperlibrary.episode.entity.Episode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aper.web.domain.paragraph.dto.ParagraphRequestDto.ItemPayload;
@@ -32,7 +31,6 @@ public class ParagraphService implements BatchService<ItemPayload> {
     private final ParagraphHelper paragraphHelper;
 
     @Override
-    @Transactional
     public void processBatch(BatchRequest<ItemPayload> request, UserDetailsImpl userDetails) {
         List<BatchOperation<ItemPayload>> operations = request.batch();
         Set<String> deletedUuids = new HashSet<>();

--- a/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphDeleteService.java
+++ b/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphDeleteService.java
@@ -1,6 +1,8 @@
 package org.aper.web.domain.paragraph.service.method;
 
 import com.aperlibrary.paragraph.entity.Paragraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aper.web.domain.paragraph.dto.ParagraphRequestDto.ItemPayload;
@@ -10,7 +12,6 @@ import org.aper.web.global.batch.service.method.BatchDeleteService;
 import org.aper.web.global.handler.ErrorCode;
 import org.aper.web.global.handler.exception.ServiceException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -26,8 +27,11 @@ public class ParagraphDeleteService implements BatchDeleteService<ItemPayload> {
     private final ParagraphRepository paragraphRepository;
     private final ParagraphHelper paragraphHelper;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void handleDeletedOperation(List<ItemPayload> itemPayloads, Set<String> deletedUuids, Long episodeId) {
         List<Paragraph> paragraphsToUpdate = new ArrayList<>();
         List<Paragraph> paragraphsToDelete = new ArrayList<>();
@@ -47,11 +51,14 @@ public class ParagraphDeleteService implements BatchDeleteService<ItemPayload> {
         }
 
         paragraphRepository.deleteAllInBatch(paragraphsToDelete);
-        log.info("Deleted UUIDs: {}", paragraphsToDelete.stream().map(Paragraph::getUuid).collect(Collectors.toList()));
         paragraphRepository.flush();
+        entityManager.clear();
 
         paragraphRepository.saveAll(paragraphsToUpdate);
         paragraphRepository.flush();
+        entityManager.clear();
+
+        log.info("Deleted UUIDs: {}", paragraphsToDelete.stream().map(Paragraph::getUuid).collect(Collectors.toList()));
         log.info("Updated UUIDs : {}", paragraphsToUpdate.stream().map(Paragraph::getUuid).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphPostService.java
+++ b/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphPostService.java
@@ -62,14 +62,15 @@ public class ParagraphPostService implements BatchPostService<ItemPayload> {
         }
 
         paragraphRepository.saveAll(paragraphsToAdd);
-        entityManager.flush();
+        paragraphRepository.flush();
+        entityManager.clear();
 
         for (ItemPayload itemPayload : itemPayloads) {
             paragraphHelper.updatePreviousParagraph(itemPayload.prev(), itemPayload.id(), paragraphsToUpdate);
         }
 
         paragraphRepository.saveAll(paragraphsToUpdate);
-        entityManager.flush();
+        paragraphRepository.flush();
         entityManager.clear();
 
         log.info("Created and updated paragraphs: {}", paragraphsToAdd.stream().map(Paragraph::getUuid).collect(Collectors.toList()));

--- a/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphPutService.java
+++ b/src/main/java/org/aper/web/domain/paragraph/service/method/ParagraphPutService.java
@@ -2,6 +2,8 @@ package org.aper.web.domain.paragraph.service.method;
 
 import com.aperlibrary.paragraph.entity.Paragraph;
 import com.aperlibrary.paragraph.entity.TextAlignEnum;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aper.web.domain.paragraph.dto.ParagraphRequestDto.ItemPayload;
@@ -26,6 +28,9 @@ public class ParagraphPutService implements BatchPutService<ItemPayload> {
     private final ParagraphRepository paragraphRepository;
     private final ParagraphHelper paragraphHelper;
     private final EnumUtil enumUtil;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Override
     public boolean handleModifiedOperation(List<ItemPayload> itemPayloads, Set<String> deletedUuids) {
@@ -54,6 +59,7 @@ public class ParagraphPutService implements BatchPutService<ItemPayload> {
 
         paragraphRepository.saveAll(paragraphsToUpdate);
         paragraphRepository.flush();
+        entityManager.clear();
         log.info("Updated paragraphs: {}", paragraphsToUpdate.stream().map(Paragraph::getUuid).collect(Collectors.toList()));
 
         return firstParagraphUpdated;

--- a/src/main/java/org/aper/web/global/config/RedisConfig.java
+++ b/src/main/java/org/aper/web/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -28,12 +29,19 @@ public class RedisConfig {
 
     @Bean
     public LettuceConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
-        redisStandaloneConfiguration.setHostName(redisProperties.getHost());
-        redisStandaloneConfiguration.setPort(redisProperties.getPort());
-        redisStandaloneConfiguration.setPassword(redisProperties.getPassword());
-        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(redisProperties.getHost());
+        redisConfig.setPort(redisProperties.getPort());
+//        if (redisProperties.getPassword() != null && !redisProperties.getPassword().isBlank()) {
+//            redisConfig.setPassword(redisProperties.getPassword());
+//        }
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()
+                .build();
+
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
     }
+
 
     @Bean
     public RedisTemplate<String, String> redisTemplate() {

--- a/src/main/resources/yml/application-dev.yml
+++ b/src/main/resources/yml/application-dev.yml
@@ -43,7 +43,7 @@ spring:
     redis:
       host: ${dev-redis.host}
       port: ${dev-redis.port}
-      password: ${dev-redis.password}
+      ssl: true
 
   elasticsearch:
     rest:

--- a/src/main/resources/yml/application-dev.yml
+++ b/src/main/resources/yml/application-dev.yml
@@ -43,7 +43,6 @@ spring:
     redis:
       host: ${dev-redis.host}
       port: ${dev-redis.port}
-      ssl: true
 
   elasticsearch:
     rest:


### PR DESCRIPTION
## 관련 Issue

* #156 

---

## 변경 사항

* OutOfMemoryError 방지를 위해 Paragraph batch 서비스(Post, Put, Delete)에 `flush()` 및 `entityManager.clear()` 적용
* ParagraphService의 @Transactional 제거하여 메모리 누수 가능성 차단

---

## Todo List

* [x] 예외 발생 시 별도 로그 추가 검토
* [x] 500개 이상 요청 시 batch 나누는 차단 프로세스 검토

---

## Check List

- [x] 포스트맨으로 확인 완료
- [x] OutOfMemoryError 재현 테스트 진행
- [x] 관련 로그 정산 Í \xcd9c력 확인

---

## 트러블 슈팅

### 1. OutOfMemoryError 발생

#### 예외 메시지

```log
java.lang.OutOfMemoryError: Java heap space
```

#### 원인 분석

> Paragraph를 `saveAll` 또는 `deleteAllInBatch`로 처리할 때,  
> 영속성 콘템스트에 객체가 누적되어 메모리 누수가 발생함.

#### 수정 사항

```java
paragraphRepository.flush();
entityManager.clear();
```

또는

```java
entityManager.flush();
entityManager.clear();
```

→ 해당 로직을 각 서비스(Post, Put, Delete)에 적용하여 문제 해결

---

📋 추가적으로 batch 분합 처리나 Kafka 비동기 토크와의 연계도 검토할 수 있음.